### PR TITLE
Fix error on nil decode

### DIFF
--- a/lib/hiera/backend/consul_backend.rb
+++ b/lib/hiera/backend/consul_backend.rb
@@ -85,7 +85,12 @@ class Hiera
           # See if we are a k/v return or a catalog return
           if res_array.length > 0
             if res_array.first.include? 'Value'
-              answer = Base64.decode64(res_array.first['Value'])
+              if res_array.first['Value'] == nil
+                # The Value is nil so we return it directly without trying to decode it ( which would fail )
+                return answer
+              else
+                answer = Base64.decode64(res_array.first['Value'])
+              end
             else
               answer = res_array
             end


### PR DESCRIPTION
I would get the following error when a value is empty in consul:

Error: Evaluation Error: Error while evaluating a Function Call, Error
from DataBinding 'hiera' while looking up 'dropwizard::instances':
undefined method `unpack' for nil:NilClass

My patch will make sure that the nil is returned directly to hiera which
knows how to deal with it.

It will also prevent the error that is currently happening when
Base64.decode64() is running against a nil value