### PR TITLE
Moved object initialization into rescue block

### DIFF
--- a/lib/hiera/backend/consul_backend.rb
+++ b/lib/hiera/backend/consul_backend.rb
@@ -110,7 +110,7 @@ class Hiera
 
           answer = nil
           begin
-            httpreq = @Net::HTTP::Get.new("#{path}#{token(path)}")
+            httpreq = Net::HTTP::Get.new("#{path}#{token(path)}")
             result = @consul.request(httpreq)
           rescue Exception => e
             Hiera.debug("[hiera-consul]: Could not connect to Consul")

--- a/lib/hiera/backend/consul_backend.rb
+++ b/lib/hiera/backend/consul_backend.rb
@@ -108,9 +108,9 @@ class Hiera
 
       def wrapquery(path)
 
-          httpreq = Net::HTTP::Get.new("#{path}#{token(path)}")
           answer = nil
           begin
+            httpreq = @Net::HTTP::Get.new("#{path}#{token(path)}")
             result = @consul.request(httpreq)
           rescue Exception => e
             Hiera.debug("[hiera-consul]: Could not connect to Consul")


### PR DESCRIPTION
This fixes the :failure: graceful option.
Without a available consul the puppet run hangs (in my case forever) in the current state.